### PR TITLE
feat: Add bottom bar and home page content

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,5 +15,4 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
   </body>
-  </body>
 </html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,7 @@ import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
 
 const isDarkTheme = ref(false);
 const icon = ref()
+const device = ref("Default")
 
 const themeChangeHandler = (event) => {
   isDarkTheme.value = event.matches;
@@ -36,46 +37,60 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <nav class="navbar navbar-expand-md fixed-top">
-      <div class="container-fluid">
-        <a class="navbar-brand" href="/">
-          <img :src= "icon" width="30" height="24" class="d-inline-block align-text-top">
-          CloudDrop
-        </a>
-        <div class="d-flex justify-content-end align-items-center">
-          <RouterLink to="/" class="link">
-            <i class="bi bi-people-fill h3 icon"></i>
-          </RouterLink>
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" aria-expanded="false" data-bs-toggle="dropdown">
-              <i class="bi bi-person-lines-fill h3 icon"></i>
-            </a>
-            <ul 
-              :class="['dropdown-menu', { 'dropdown-menu-dark': isDarkTheme }]"
-              aria-labelledby="navbarDropdown"
-              style="position: absolute; top: 100%; left: auto; right: 0;">
-              <li>
-                <RouterLink to="/about" class="dropdown-item">
-                  <i class="bi bi-collection-fill h5 icon"></i> Temporary Storage
-                </RouterLink>
-              </li>
-              <li>
-                <RouterLink to="/history" class="dropdown-item">
-                  <i class="bi bi-clock-history h5 icon" ></i> History
-                </RouterLink>
-              </li>
-            </ul>
-          </li>
-        </div>
+  <nav class="navbar navbar-expand-md fixed-top">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="/">
+        <img :src= "icon" width="30" height="24" class="d-inline-block align-text-top">
+        CloudDrop
+      </a>
+      <div class="d-flex justify-content-end align-items-center">
+        <RouterLink to="/" class="link">
+          <i class="bi bi-people-fill h3 icon"></i>
+        </RouterLink>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" aria-expanded="false" data-bs-toggle="dropdown">
+            <i class="bi bi-person-lines-fill h3 icon"></i>
+          </a>
+          <ul 
+            :class="['dropdown-menu', { 'dropdown-menu-dark': isDarkTheme }]"
+            aria-labelledby="navbarDropdown"
+            style="position: absolute; top: 100%; left: auto; right: 0;">
+            <li>
+              <RouterLink to="/about" class="dropdown-item">
+                <i class="bi bi-collection-fill h5 icon"></i> Temporary Storage
+              </RouterLink>
+            </li>
+            <li>
+              <RouterLink to="/history" class="dropdown-item">
+                <i class="bi bi-clock-history h5 icon" ></i> History
+              </RouterLink>
+            </li>
+          </ul>
+        </li>
       </div>
-    </nav>
+    </div>
+  </nav>
+  
+  <div>
+    <RouterView />
+  </div>
 
-  <RouterView />
+  <nav class="navbar navbar-expand-md fixed-bottom d-flex justify-content-center navbar-bottom">
+    <div class="card">
+      <div class="card-body d-flex justify-content-center">
+        <p class="card-text">裝置名稱：{{ device }}</p>
+      </div>
+    </div>
+  </nav>
 </template>
 
 <style scoped>
 .navbar {
   background-color: var(--color-background-mute);
+}
+
+.navbar-bottom {
+  background-color: var(--color-background);
 }
 
 .navbar-brand:hover, .icon:hover, .link:hover {
@@ -114,5 +129,9 @@ onBeforeUnmount(() => {
 
 li {
   list-style-type: none;
+}
+
+.card {
+  background-color: var(--color-card-background);
 }
 </style>

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -34,6 +34,8 @@
   --color-text: var(--vt-c-text-light-1);
 
   --section-gap: 160px;
+
+  --color-card-background: var(--vt-c-white-soft);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -47,6 +49,8 @@
 
     --color-heading: var(--vt-c-text-dark-1);
     --color-text: var(--vt-c-text-dark-2);
+
+    --color-card-background: var(--vt-c-white-soft);
   }
 }
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -29,7 +29,7 @@ a,
 
   #app {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     padding: 0 2rem;
   }
 }

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -1,14 +1,12 @@
 <template>
-    <div class="home">
-      <h1>This is an home page</h1>
+  <div class="row">
+    <div class="col-12 text-center">
+      等待裝置配對~ Σ Σ (」○ ω○ )／
     </div>
-  </template>
-  
-  <style scoped>
-  .home {
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-  }
-  </style>
+  </div>
+</template>
+
+<style scoped>
+
+</style>
   


### PR DESCRIPTION
## Changes
1. Add bottom bar to display device info
2. Add content when no device connect

## Test
1. Run `npm run dev`
2. See

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/194d097b-dc78-4617-9385-cb818321fe0e">


<img width="1463" alt="image" src="https://github.com/user-attachments/assets/5c487436-dedb-4794-9e05-2928bfb16555">


★ if have any color recommendation, just add comments!!