### PR TITLE
Feature/esther/cns-66 delete api for all files

### DIFF
--- a/backend/src/clients/redisClient.js
+++ b/backend/src/clients/redisClient.js
@@ -130,6 +130,25 @@ class RedisClient {
             throw err;
         }
     };
+
+    deleteByPattern = async (pattern) => {
+        let cursor = 0;
+        do {
+            try {
+                const reply = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', '100');
+                cursor = reply['cursor'];
+                const keys = reply['keys'];
+
+                if (keys.length > 0) {
+                    await this.client.del(keys);
+                    logWithFileInfo('info', `[RedisClient] Deleted keys: ${keys.join(', ')}`);
+                }
+            } catch (err) {
+                logWithFileInfo('error', `[RedisClient] Error flushing keys by pattern ${pattern}`, err);
+                throw err;
+            }
+        } while (cursor !== 0);
+    };
 }
 
 const redisClient = new RedisClient();

--- a/backend/src/controllers/internetFileController.js
+++ b/backend/src/controllers/internetFileController.js
@@ -44,7 +44,8 @@ class InternetFileController {
     deleteFile = async (req, res) => {
         logWithFileInfo('info', '----InternetFileController.deleteFile');
         try {
-            await this.internetFileService.deleteFile(req, res);
+            const response = await this.internetFileService.deleteFile(req, res);
+            res.send(response);
             logWithFileInfo('info', 'File deleted successfully.');
         } catch (error) {
             logWithFileInfo('error', 'Error deleting file. ', error);
@@ -54,6 +55,18 @@ class InternetFileController {
             } else {
                 res.status(500).send(errorMsg);
             }
+        }
+    };
+
+    deleteAllFiles = async (req, res) => {
+        logWithFileInfo('info', '----InternetFileController.deleteAllFiles');
+        try {
+            await this.internetFileService.deleteAllFiles();
+            logWithFileInfo('info', 'All files deleted successfully.');
+            res.send({ message: 'All files deleted successfully.' });
+        } catch (error) {
+            logWithFileInfo('error', 'Error deleting all the files.', error);
+            res.status(500).send({ message: 'Failed to delete all the files.', error: error.message });
         }
     };
 }

--- a/backend/src/controllers/internetFileController.js
+++ b/backend/src/controllers/internetFileController.js
@@ -61,9 +61,9 @@ class InternetFileController {
     deleteAllFiles = async (req, res) => {
         logWithFileInfo('info', '----InternetFileController.deleteAllFiles');
         try {
-            await this.internetFileService.deleteAllFiles();
+            const response = await this.internetFileService.deleteAllFiles();
             logWithFileInfo('info', 'All files deleted successfully.');
-            res.send({ message: 'All files deleted successfully.' });
+            res.send(response);
         } catch (error) {
             logWithFileInfo('error', 'Error deleting all the files.', error);
             res.status(500).send({ message: 'Failed to delete all the files.', error: error.message });

--- a/backend/src/routes/internetFileRoutes.js
+++ b/backend/src/routes/internetFileRoutes.js
@@ -31,7 +31,7 @@ internetFileRouter.post(
     multerErrorHandling
 );
 internetFileRouter.get('/:userId/download/:way/:fileId', internetFileController.download);
-internetFileRouter.delete('/delete/:fileId', internetFileController.deleteFile);
+internetFileRouter.delete('/delete/file/:fileId', internetFileController.deleteFile);
 internetFileRouter.delete('/delete/all-files', internetFileController.deleteAllFiles);
 
 export default internetFileRouter;

--- a/backend/src/routes/internetFileRoutes.js
+++ b/backend/src/routes/internetFileRoutes.js
@@ -32,5 +32,6 @@ internetFileRouter.post(
 );
 internetFileRouter.get('/:userId/download/:way/:fileId', internetFileController.download);
 internetFileRouter.delete('/delete/:fileId', internetFileController.deleteFile);
+internetFileRouter.delete('/delete/all-files', internetFileController.deleteAllFiles);
 
 export default internetFileRouter;

--- a/backend/src/services/internetFileService.js
+++ b/backend/src/services/internetFileService.js
@@ -112,25 +112,37 @@ class InternetFileService {
 
     deleteFile = async (req, res) => {
         const fileId = req.params.fileId;
-        const __filename = fileURLToPath(import.meta.url);
-        const __dirname = path.dirname(__filename);
-        const rootPath = path.join(__dirname, '../../uploads');
-
-        const files = await fs.promises.readdir(rootPath);
+        const files = await fs.promises.readdir(this.uploadPath);
         const matchedFile = files.find((file) => {
             const filename = path.basename(file);
             const extractedFileId = filename.split('_')[0];
             return extractedFileId === fileId;
         });
 
-        // 沒有匹配的檔案
         if (!matchedFile) {
             throw new Error('File not found');
         }
 
-        const filePath = path.join(rootPath, matchedFile);
-        await fs.promises.unlink(filePath); // 刪除檔案
+        const filePath = path.join(this.uploadPath, matchedFile);
+        // 刪除 /upload 中的檔案
+        await fs.promises.unlink(filePath);
+        // 刪除 Redis 中的 hash 紀錄
+        await redisClient.connect();
+        await redisClient.del(`fileHash:${fileId}`);
         const response = { message: 'File deleted successfully' };
+        return response;
+    };
+
+    deleteAllFiles = async (req, res) => {
+        const files = await fs.promises.readdir(this.uploadPath);
+        for (const file of files) {
+            const filePath = path.join(this.uploadPath, file);
+            await fs.promises.unlink(filePath);
+        }
+        // 刪除 Redis 中所有 file hash 的紀錄
+        await redisClient.connect();
+        await redisClient.deleteByPattern('fileHash:*');
+        const response = { message: 'All files deleted successfully' };
         return response;
     };
 }

--- a/backend/src/services/internetFileService.js
+++ b/backend/src/services/internetFileService.js
@@ -128,7 +128,7 @@ class InternetFileService {
         await fs.promises.unlink(filePath);
         // 刪除 Redis 中的 hash 紀錄
         await redisClient.connect();
-        await redisClient.del(`fileHash:${fileId}`);
+        await redisClient.deleteHashByFileId(fileId);
         const response = { message: 'File deleted successfully' };
         return response;
     };

--- a/backend/src/services/internetFileService.js
+++ b/backend/src/services/internetFileService.js
@@ -117,7 +117,12 @@ class InternetFileService {
         const rootPath = path.join(__dirname, '../../uploads');
 
         const files = await fs.promises.readdir(rootPath);
-        const matchedFile = files.find((file) => path.basename(file, path.extname(file)) === fileId);
+        const matchedFile = files.find((file) => {
+            const filename = path.basename(file);
+            const extractedFileId = filename.split('_')[0];
+            return extractedFileId === fileId;
+        });
+
         // 沒有匹配的檔案
         if (!matchedFile) {
             throw new Error('File not found');
@@ -125,7 +130,8 @@ class InternetFileService {
 
         const filePath = path.join(rootPath, matchedFile);
         await fs.promises.unlink(filePath); // 刪除檔案
-        res.send({ message: 'File deleted successfully' });
+        const response = { message: 'File deleted successfully' };
+        return response;
     };
 }
 


### PR DESCRIPTION
## Change
- add one endpoint for delete all files (delete files in `/upload` folder and file hash in Redis at the same time)
http://localhost:3000/api/v1/delete/all-files
- add delete the file hash in Redis when deleting certain file
http://localhost:3000/api/v1/delete/file/{fileId}
- add functions in Redis Client to delete certain pattern of keys or delete certain file hash with fileId

## Test
First of all, upload some files for testing.
<img width="698" alt="image" src="https://github.com/user-attachments/assets/685fb46e-f17c-47fd-91b4-95d5ac5472a6" />


Example for deleting certain file: 
ex. DELETE http://localhost:3000/api/v1/delete/file/16461b30-a5bf-4dac-af49-d7773886afb8

Example for deleting all files: 
ex. DELETE http://localhost:3000/api/v1/delete/all-files

You can check `/upload` folder and Redis to see if it already deleted the file and the file hash.

### How to check Redis really works?
1. Open Redis CLI
```
redis-cli
```

2. List all the keys (file hash)
```
KEYS '*' 
```
 If you successfully deleted all files, there should be no key (file hash) in Redis.
