### PR TITLE
CNS-85 style: disable modal hide when click outside

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -343,6 +343,7 @@ onBeforeUnmount(() => {
         tabindex="-1"
         aria-labelledby="roomModalLabel"
         aria-hidden="true"
+        data-bs-backdrop="static"
         v-on="{ 'hide.bs.modal': onModalHide }"
     >
         <div class="modal-dialog">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -85,6 +85,16 @@ const handleBackspace = async (index) => {
 };
 
 const joinRoom = async () => {
+    // join new room
+    let inputRoomToken = characters.join('').toUpperCase();
+
+    // check whether the user is alreadly in the room
+    if (store.roomToken === inputRoomToken) {
+        alertStore.addAlert('已在該房間中！', 'warn');
+        roomModalInstance.hide();
+        return;
+    }
+
     // leave old room
     if (store.roomToken) {
         const { data } = await axios.post(`${BE_API_BASE_URL}/rooms/${store.roomToken}/leave`, { user: store.user });
@@ -93,8 +103,7 @@ const joinRoom = async () => {
         }
     }
 
-    // join new room
-    let inputRoomToken = characters.join('').toUpperCase();
+
     if (inputRoomToken.length === 5) {
         store.roomToken = inputRoomToken;
         sessionStorage.setItem('roomToken', inputRoomToken);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -376,7 +376,10 @@ onBeforeUnmount(() => {
                     </div>
                 </div>
                 <div class="modal-footer justify-content-center border-0">
-                    <button class="btn btn-secondary" type="submit" data-bs-dismiss="modal" @click="leaveRoom">
+                    <button class="btn btn-secondary" type="button" data-bs-dismiss="modal">
+                        關閉
+                    </button>
+                    <button class="btn btn-secondary" type="button" data-bs-dismiss="modal" @click="leaveRoom">
                         離開
                     </button>
                     <button class="btn btn-success" type="submit" @click="joinRoom">加入</button>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -101,7 +101,7 @@ const joinRoom = async () => {
         roomModalInstance.hide();
         await router.push({ path: '/', query: { roomToken: inputRoomToken } });
     } else {
-        alertStore.addAlert('邀請碼不存在', 'error');
+        alertStore.addAlert('請輸入五碼的邀請碼', 'error');
     }
 };
 

--- a/frontend/src/components/LoginModal.vue
+++ b/frontend/src/components/LoginModal.vue
@@ -98,7 +98,14 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="modal fade" id="loginModal" tabindex="-1" aria-labelledby="loginModalLabel" aria-hidden="true">
+    <div 
+        class="modal fade"
+        id="loginModal"
+        tabindex="-1"
+        aria-labelledby="loginModalLabel"
+        aria-hidden="true"
+        data-bs-backdrop="static"
+    >
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header pt-3 pb-2 border-0">
@@ -114,7 +121,21 @@ onMounted(() => {
                             <label for="password">密碼</label>
                             <input id="password" class="w-75" type="password" v-model="password" required />
                         </div>
-                        <button type="submit" class="btn btn-primary" v-if="loginStatus === 'default'">登入</button>
+                        <button
+                            v-if="loginStatus === 'default'"
+                            type="button"
+                            class="btn btn-secondary mx-1"
+                            data-bs-dismiss="modal"
+                        >
+                            取消
+                        </button>
+                        <button
+                            v-if="loginStatus === 'default'"
+                            type="submit"
+                            class="btn btn-primary mx-1"  
+                        >
+                            登入
+                        </button>
                         <div
                             class="text-success d-flex gap-2 justify-content-center"
                             v-else-if="loginStatus === 'success'"

--- a/frontend/src/components/LogoutModal.vue
+++ b/frontend/src/components/LogoutModal.vue
@@ -72,7 +72,14 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="modal fade" id="logoutModal" tabindex="-1" aria-labelledby="logoutModalLabel" aria-hidden="true">
+    <div 
+        class="modal fade"
+        id="logoutModal"
+        tabindex="-1"
+        aria-labelledby="logoutModalLabel"
+        aria-hidden="true"
+        data-bs-backdrop="static"
+    >
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header pt-3 pb-2 border-0">


### PR DESCRIPTION
## Changes
- disable hide when click outside for room, login, logout modal
- add cancel for login modal

## Test
1. start frontend and backend
2. test outside when modal open. Expected: modal won't hide unless cancel is press

cancel for login
<img width="504" alt="image" src="https://github.com/user-attachments/assets/566c64f3-5f18-4f7e-9f7d-c7d558e5c13b" />

after login success
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/db6d48e0-1554-4a45-9b0c-7d8038cc595d" />
