### PR TITLE
CNS-89 refactor: change cookie secure

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,6 @@ BLOOM_FILTER_ERROR_RATE=0.001
 # JWT
 ACCESS_TOKEN_SECRET=put-any-string-here
 REFRESH_TOKEN_SECRET=put-any-string-here
+
+# Cookie
+COOKIE_SECURE=false

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -15,3 +15,6 @@ BLOOM_FILTER_ERROR_RATE=0.001
 # JWT
 ACCESS_TOKEN_SECRET=put-any-string-here
 REFRESH_TOKEN_SECRET=put-any-string-here
+
+# Cookie
+COOKIE_SECURE=true

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -46,8 +46,16 @@ class AuthController {
         try {
             const loginResult = await this.authService.login(email, password);
             if (loginResult.success) {
-                res.cookie('accessToken', loginResult.tokens.accessToken, { httpOnly: true, secure: false });
-                res.cookie('refreshToken', loginResult.tokens.refreshToken, { httpOnly: true, secure: false });
+                res.cookie('accessToken', loginResult.tokens.accessToken, {
+                    httpOnly: true,
+                    sameSite: 'Lax',
+                    secure: process.env.COOKIE_SECURE,
+                });
+                res.cookie('refreshToken', loginResult.tokens.refreshToken, {
+                    httpOnly: true,
+                    sameSite: 'Lax',
+                    secure: process.env.COOKIE_SECURE,
+                });
                 res.status(200).json({ message: 'Login success', data: loginResult.data });
             } else {
                 res.status(401).json({ message: loginResult.error });
@@ -60,8 +68,16 @@ class AuthController {
 
     logout = async (req, res) => {
         logWithFileInfo('info', '-----logout-----');
-        res.clearCookie('accessToken');
-        res.clearCookie('refreshToken');
+        res.clearCookie('accessToken', {
+            httpOnly: true,
+            sameSite: 'Lax',
+            secure: process.env.COOKIE_SECURE,
+        });
+        res.clearCookie('refreshToken', {
+            httpOnly: true,
+            sameSite: 'Lax',
+            secure: process.env.COOKIE_SECURE,
+        });
         logWithFileInfo('info', `user ${req.user.userID} logout`);
         res.status(200).json({ message: `user ${req.user.userID} logout` });
     };

--- a/backend/src/middlewares/jwtMiddleware.js
+++ b/backend/src/middlewares/jwtMiddleware.js
@@ -32,7 +32,11 @@ const jwtMiddleware = async (req, res, next) => {
                 // regenerate accessToken
                 logWithFileInfo('info', 'accessToken expired, regenerate accessToken');
                 const newAccessToken = authService.generateAccessToken(userData);
-                res.cookie('accessToken', newAccessToken, { httpOnly: true, secure: true });
+                res.cookie('accessToken', newAccessToken, {
+                    httpOnly: true,
+                    sameSite: 'Lax',
+                    secure: process.env.COOKIE_SECURE,
+                });
             } catch (err) {
                 if (err.name === 'TokenExpiredError') {
                     logWithFileInfo('info', `invalid refreshToken when go to ${toPath}`);


### PR DESCRIPTION
## Changes 
cookie setting
- `secure` -- different setting in development and production (see .env.example and .env.production in /backend)
- `sameSite` -- 'Lax' is default value, but some website (Ex. Firefox) will throw warning if without writing it directly

## Need to Do
Set up .env according to .env.example or .env.production